### PR TITLE
Changes REGEX Patter for better file-extension-guessing

### DIFF
--- a/src/utils/media_sender.py
+++ b/src/utils/media_sender.py
@@ -42,7 +42,7 @@ class MediaSender():
         """
         self.interface_layer = interface_layer
         self.storage_path = storage_path
-        self.file_extension_regex = re.compile("\.([0-9a-z]+)($|\?[^\s]*$)")
+        self.file_extension_regex = re.compile("^.*\.([0-9a-z]+)(?:[\?\/][^\s]*)?$")
         self.MEDIA_TYPE = None
 
     def send_by_url(self, jid, file_url, caption=None):
@@ -118,7 +118,7 @@ class MediaSender():
         self.interface_layer.toLower(TextMessageProtocolEntity("{!}", to=jid))
 
     def _get_file_ext(self, url):
-        return self.file_extension_regex.findall(url)[0][0]
+        return self.file_extension_regex.findall(url)[0]
 
     def _build_file_path(self, url):
         id = hashlib.md5(url).hexdigest()


### PR DESCRIPTION
I had an error when a image ended continuous  with a slash ( /and/some/random/stuff?width=100 ) and the regex pattern tried to guess the correct image extension. 

for example:
/i harry potter (yes I really did this xD)
returns the url:
http://vignette1.wikia.nocookie.net/harrypotter/images/b/b2/2001-Harry-Potter-and-the-Sorcerer-s-Stone-Promotional-Shoot-HQ-harry-potter-11097228-1600-1960.jpg/revision/latest/scale-to-width-down/145?cb=20141122213655

I also marked the /random/stuff and ?some=randomstuff as non capturing.