### PR TITLE
When using bing`s image results, users can choose to source directly from bing`s cached thumbnail instead of from the original website.

### DIFF
--- a/src/utils/media_sender.py
+++ b/src/utils/media_sender.py
@@ -44,10 +44,11 @@ class MediaSender():
         self.file_extension_regex = re.compile("^.*\.([0-9a-z]+)(?:[\?\/][^\s]*)?$")
         self.MEDIA_TYPE = None
 
-    def send_by_url(self, jid, file_url, caption=None):
+    def send_by_url(self, jid, file_url, caption=None, ftype=None):
         """ Downloads and send a file_url """
         try:
             # self.interface_layer.toLower(TextMessageProtocolEntity("{...}", to=jid))
+            if ftype is not None: file_url = file_url + str(ftype)
             file_path = self._download_file(file_url)
             self.send_by_path(jid, file_path, caption)
         except Exception as e:

--- a/src/views/bing.py
+++ b/src/views/bing.py
@@ -14,7 +14,13 @@ class BingViews():
             ("/i(mage)?\s(?P<term>[^$]+)$", self.bing_image_search)
         ]
 
-    def bing_image_search(self, message, match):
+    def bing_image_search(self, message, match, thumbnail=None):
         req = requests.get("https://api.datamarket.azure.com/Bing/Search/v1/Image?Query=%27{}%27&$format=json&$top=1".format(match.group("term")), auth=("",config.bing_api))
-        image_url = urllib.unquote(req.json()['d']['results'][0]['MediaUrl'].encode('utf-8'))
-        self.image_sender.send_by_url(jid=message.getFrom(), file_url=image_url)
+
+        if thumbnail is not None:
+            image_url = urllib.unquote(req.json()['d']['results']['Thumbnail']['MediaUrl'].encode('utf-8'))
+            self.image_sender.send_by_url(jid=message.getFrom(), file_url=image_url, ftype=".jpg")
+
+        else:
+            image_url = urllib.unquote(req.json()['d']['results'][0]['MediaUrl'].encode('utf-8'))
+            self.image_sender.send_by_url(jid=message.getFrom(), file_url=image_url)


### PR DESCRIPTION
When using bing`s image results, users can choose to source directly from bing`s cached thumbnail instead of from the original website.
